### PR TITLE
Added _item and _enum along with a few more JS methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,39 @@ This is a script that adds [JavaScript-style string functionality](https://devel
 After saving the `javascript_strings.ahk` file, [`#Include`](https://www.autohotkey.com/docs/v2/lib/_Include.htm) it at the top of your script.  
 It's important to ensure the `#Include` happens before using any of the functions/property as this will throw an error.  
 
+### List of Changes in this fork:
+## Additional methods:
+- String.at()
+- String.replaceAll()
+- String.matchAll()
+- String.valueOf()
+
+## Other changes:
+- Added __Item 
+- Added __Enum 
+
+### These allow direct access for values, so you can do things like:
+
+```
+Msgbox('hello'[2])       ; -> prints 'e'
+For (char in 'hello') {
+  Msgbox(char)
+}                        ; prints each character of 'hello' in a new msgbox
+```
+### You can use those with variables too of course.
+
+```
+myString := 'hello'
+Msgbox(myString[5])    ; -> prints 'o'
+```
+
 ### List of Properties:
 
 * [`length`](#length) - Returns the length of the string.
 
 ### List of Methods:
 
+* [`at(index)`](#at) - Returns the character at a specified index or position. *Can search negative indices.*
 * [`charAt(index)`](#charAt) - Returns the character at a specified index/position.  
 * [`charCodeAt(index)`](#charCodeAt) - Returns the Unicode of the character at a specified index/position.  
 * [`concat(String1 [,String2, StringN])`](#concat) - Returns two or more joined strings.
@@ -23,6 +50,7 @@ It's important to ensure the `#Include` happens before using any of the function
 * [`padStart(length [, pad_str])`](#padStart) - Pads the beginning of the string to a given length with a given string.  
 * [`repeat(number_of_times)`](#repeat) - Repeats the string as many times as requested.
 * [`replace(regex_pattern [, replacement])`](#replace) - Searches a string for a value or regular expression and replace it.  
+* [`replaceAll(regex_pattern [, replacement])`](#replaceAll) - Searches a string for all occurances of a value or regex and replaces them.  
 * [`search(regex_pattern)`](#search) - Searches a string for a value or regular expression and returns the index/position of the match.  
 * [`slice([start_pos, end_pos])`](#slice) - Extracts a part of a string and returns it.  
 * [`split(delimiter, max_limit)`](#split) - Splits a string into an array of substrings.  
@@ -43,6 +71,13 @@ It's important to ensure the `#Include` happens before using any of the function
       MsgBox(str.length ' characters')  ; 10 characters
 
 ### Methods:
+
+##### at()
+* `at(index)` - Returns the character at a specified index/position. Can search negative indices.  
+`index` is the string position of the desired character.  
+
+      str := 'AutoHotkey'
+      MsgBox(str.charAt(-6))  ; H
 
 ##### charAt()
 * `charAt(index)` - Returns the character at a specified index/position.  
@@ -109,12 +144,25 @@ If end_pos is omitted, the last character of the string is the ending position.
       MsgBox(str.lastIndexOf('Hot', 10))  ; 5
 
 ##### match()
-* `match(regex_pattern)` - Searches a string for a value or regular expression, and returns a [RegExMatchInfo object](https://www.autohotkey.com/docs/v2/lib/RegExMatch.htm#MatchObject).
+* `match(regex_pattern)` - Searches a string for a value or regular expression, and returns the match.
 `regex_pattern` is a valid RegEx pattern.  
 This gives strings a built-in [RegExMatch()](https://www.autohotkey.com/docs/v2/lib/RegExMatch.htm).
 
       str := 'Auto Hot Key'
       MsgBox(str.match('\w+ (\w+) \w+')[1])  ; Hot
+
+##### matchAll()
+* `match(regex_pattern)` - Searches a string for a value or regular expression, and returns a [RegExMatchInfo object](https://www.autohotkey.com/docs/v2/lib/RegExMatch.htm#MatchObject).
+`regex_pattern` is a valid RegEx pattern.  
+This gives strings a built-in [RegExMatch()](https://www.autohotkey.com/docs/v2/lib/RegExMatch.htm).
+
+      str := 'Auto Hot key is the best Hot Key program'
+      y := str.match('\w+ (\w+) \w+')[1]  ;returns ['Auto Hot Key', 'Hot']
+      for eachStr in y {
+            MsgBox(eachStr)               ;Prints 'Auto Hot Key' and then prints 'Hot'
+      }
+      ; 
+
 
 ##### padEnd()
 * `padEnd(length [, pad_str:=' '])` - Pads the end of the string to a given length using a given string.  
@@ -147,14 +195,27 @@ If omitted, space is used.
       MsgBox(str1.repeat(2) str2.repeat(2) '!') ; Happy Happy Joy Joy!
 
 ##### replace()
-* `replace(regex_pattern [, replacement:=''])` - Searches a string for a value or regular expression and replace it.  
+* `replace(regex_pattern [, replacement:='', mode := 0])` - Searches a string for a value or regular expression and replace it.
+To remove more than one occurance either use replaceAll() or set mode equal to 1 (or any positive integer), both accept regex.
+
 This gives strings a built-in [RegExReplace()](https://www.autohotkey.com/docs/v2/lib/RegExReplace.htm).
 `regex_pattern` is a valid RegEx pattern.  
 `replacement` defines the text to replace the matched text with. Because this is a RegEx process, it can included backreferences such as `$1`.  
 If replacement is omitted, the matched text is removed.  
+Match is case sensitive by default. 
 
       str := 'ManualHotkey'
-      MsgBox(str.replace('^Manual', 'Auto'))  ; AutoHotkey
+      MsgBox(str.replace('Manual', 'Auto'))  ; AutoHotkey
+
+##### replaceAll()
+* `replaceAll(regex_pattern [, replacement:='', &OutputVarCount, Limit := -1, StartingPos := 1])` - Searches a string for a value or regular expression and replace all occurances of it up to Limit, where -1 replaces all.  
+This gives strings a built-in [RegExReplace()](https://www.autohotkey.com/docs/v2/lib/RegExReplace.htm).
+`regex_pattern` can be a valid RegEx pattern.  
+`replacement` defines the text to replace every occurance of the matched text with. Because this is a RegEx process, it can included backreferences such as `$1`.  
+If replacement is omitted, each occurance of matched text is removed.  
+
+      str := 'The best version of AutoHotkey is definitely AutoHotkey v2.'
+      MsgBox(str.replaceAll('AutoHotkey', 'AHK'))  ; 'The best version of AHK is definitely AHK v2.'
 
 ##### search()
 * `search(regex_pattern)` - Searches a string for a value or regular expression and returns the index/position of the match.  
@@ -238,11 +299,17 @@ Whitespace includes spaces, tabs, linefeeds, and carriage returns.
 Whitespace includes spaces, tabs, linefeeds, and carriage returns.
 
       str := '    AHK    '
-      MsgBox(str.trimEnd() ; '    AHK'
+      MsgBox(str.trimEnd()) ; '    AHK'
 
 ##### trimStart()
 * `trimStart()` - Returns string after removing all whitespace from the beginning of the string.  
 Whitespace includes spaces, tabs, linefeeds, and carriage returns.  
 
       str := '    AHK    '
-      MsgBox(str.trimStart() ; 'AHK    '
+      MsgBox(str.trimStart()) ; 'AHK    '
+
+##### valueOf()
+* `valueOf()` - Returns the string 
+
+      str := 'AHK'
+      MsgBox(str.valueOf()) ; 'AHK'

--- a/src/javascript_strings.ahk
+++ b/src/javascript_strings.ahk
@@ -31,7 +31,7 @@ class __javascript_strings {
 		EnumElements(&char) {
 			char := StrGet(StrPtr(this) + 2*pos, 1)
 			return ++pos <= len
-		}
+		}		
 		EnumIndexAndElements(&index, &char) {
 			char := StrGet(StrPtr(this) + 2*pos, 1), index := ++pos
 			return pos <= len
@@ -63,10 +63,15 @@ class __javascript_strings {
     static lastIndexOf(value, end_pos:=unset) => InStr(SubStr(this, 1, IsSet(end_pos) ? end_pos : unset), value,,, -1)
     
     ; replace() - Searches a string for a pattern, and returns a string where the first match is replaced
-    static replace(regex, replacement:='') => RegExReplace(this, regex, replacement)
-
+    static replace(needle, replacement:='', mode := 0) {
+        if !mode {
+            return StrReplace(this, needle, replacement, 1,, 1)
+        } else {
+            return RegExReplace(this, regex := needle, replacement)
+        }
+    }
     ; replaceAll() - Searches a string for a pattern, and returns a string where every match is replaced
-    static replaceAll(args*) => StrReplace(this, args*)
+    static replaceAll(args*) => RegExReplace(this, args*)
 
     ; search() - Searches a string for a value, or regular expression, and returns the index (position) of the match
     static search(regex) => RegExMatch(this, regex)

--- a/src/javascript_strings.ahk
+++ b/src/javascript_strings.ahk
@@ -1,127 +1,170 @@
 class __javascript_strings {
     static __New() {
-        String.Prototype.DefineProp := Object.Prototype.DefineProp
-        
-        ; === Properties ===
-        String.Prototype.DefineProp('length', {get: (this) => StrLen(this)})
-        
-        ; === Methods ===
-        ; charAt() - Returns the character at a specified index (position)
-        String.Prototype.DefineProp('charAt', {call: (this, index) => SubStr(this, index, 1)})
-        
-        ; charCodeAt() - Returns the Unicode of the character at a specified index
-        String.Prototype.DefineProp('charCodeAt', {call: (this, index) => Ord(SubStr(this, index, 1))})
-        
-        ; concat() - Returns two or more joined strings
-        String.Prototype.DefineProp('concat', {call:concat})
-        
-        ; endsWith() - Returns if a string ends with a specified value
-        String.Prototype.DefineProp('endsWith', {call: endsWith})
-        
-        ; includes() - Returns true if a string contains a specified value
-        String.Prototype.DefineProp('includes', {call: (this, value, start_pos:=1) => InStr(this, value,, start_pos) ? 1 : 0})
-        
-        ; indexOf() - Returns the index (position) of the first occurrence of a value in a string
-        String.Prototype.DefineProp('indexOf', {call: (this, value, start_pos:=1) => InStr(this, value,, start_pos)})
-        
-        ; lastIndexOf() - Returns the index (position) of the last occurrence of a value in a string
-        String.Prototype.DefineProp('lastIndexOf', {call: (this, value, end_pos:=unset) => InStr(SubStr(this, 1, IsSet(end_pos) ? end_pos : unset), value,,, -1)})
-        
-        ; match() - Searches a string for a value, or a regular expression, and returns the matches
-        String.Prototype.DefineProp('match', {call: match})
-        
-        ; padEnd() - Pads the end of the string to a given length with with a given string. Repeats if needed.
-        String.Prototype.DefineProp('padEnd', {call: padEnd})
-        
-        ; padStart() - Pads the end of the string to a given length with with a given string. Repeats if needed.
-        String.Prototype.DefineProp('padStart', {call: padStart})
-        
-        ; repeat() - Returns a new string with a number of copies of a string
-        String.Prototype.DefineProp('repeat', {call: repeat})
-        
-        ; replace() - Searches a string for a pattern, and returns a string where the first match is replaced
-        String.Prototype.DefineProp('replace', {call: (this, regex, replacement:='') => RegExReplace(this, regex, replacement)})
-        
-        ; search() - Searches a string for a value, or regular expression, and returns the index (position) of the match
-        String.Prototype.DefineProp('search', {call: (this, regex) => RegExMatch(this, regex)})
-        
-        ; slice() - Extracts a part of a string and returns a new string
-        String.Prototype.DefineProp('slice', {call: (this, start:=1, end:=unset) => SubStr(this, start, IsSet(end) ? end-start+1 : unset)})
-        
-        ; split() - Splits a string into an array of substrings
-        String.Prototype.DefineProp('split', {call: (this, delimiter:='', limit:=-1) => (limit = 0) ? [] : StrSplit(this, delimiter,'', limit)})
-        
-        ; startsWith() - Checks whether a string begins with specified characters
-        String.Prototype.DefineProp('startsWith', {call: startsWith})
-        
-        ; substring() - Extracts characters from a string, between two specified indices (positions)
-        String.Prototype.DefineProp('substring', {call: (this, start, end:=unset) => SubStr(this, start, IsSet(end) ? end-start+1 : unset)})
-        
-        ; toLowerCase() - Returns a string converted to lowercase letters
-        String.Prototype.DefineProp('toLowerCase', {call: (this) => StrLower(this)})
-        
-        ; toUpperCase() - Returns a string converted to uppercase letters
-        String.Prototype.DefineProp('toUpperCase', {call: (this) => StrUpper(this)})
-        
-        ; trim() - Returns a string with removed whitespaces
-        String.Prototype.DefineProp('trim', {call:(this, chars:=' \t`n`r') => Trim(this, chars)})
-        
-        ; trimEnd() - Returns a string with removed whitespaces from the end
-        String.Prototype.DefineProp('trimEnd', {call:(this, chars:=' \t`n`r') => RTrim(this, chars)})
-        
-        ; trimStart() - Returns a string with removed whitespaces from the start
-        String.Prototype.DefineProp('trimStart', {call:(this, chars:=' \t`n`r') => LTrim(this, chars)})
-        return
-        
-        ;=======================
-        concat(this, strings*) {
-            for str in strings
-                this .= str
-            return this
-        }
-        
-        endsWith(this, search_str, end_pos:=unset) {
-            str_len := StrLen(this)
-            if !IsSet(end_pos)
-                end_pos := str_len
-            srch_len := StrLen(search_str)
-            if (SubStr(this, end_pos-srch_len+1, srch_len) = search_str)
-                return 1
-            return 0
-        }
-        
-        match(this, regex) {
-            RegExMatch(this, regex, &m)
-            return m
-        }
-        
-        padEnd(this, length, pad:=' ') {
-            while (StrLen(this) != length)
-                loop parse pad
-                    this .= A_LoopField
-                until (StrLen(this) = length)
-            return this
-        }
-        
-        padStart(this, length, pad:=' ') {
-            while (StrLen(this) != length)
-                loop parse pad
-                    this := A_LoopField this
-                until (StrLen(this) = length)
-            return this
-        }
-        
-        repeat(this, count) {
-            str := ''
-            loop count
-                str .= this
-            return str
-        }
-        
-        startsWith(this, search_str, start_pos:=1) {
-            if (search_str = SubStr(this, start_pos, StrLen(search_str)))
-                return 1
-            return 0
-        }
+		__ObjDefineProp := Object.Prototype.DefineProp
+		for ____javascript_strings_Prop in __javascript_strings.OwnProps()
+			if SubStr(____javascript_strings_Prop, 1, 2) != "__"
+				__ObjDefineProp(String.Prototype, ____javascript_strings_Prop, __javascript_strings.GetOwnPropDesc(____javascript_strings_Prop))
+		__ObjDefineProp(String.Prototype, "__Item", {get:(args*)=>__javascript_strings.__Item[args*]})
+		__ObjDefineProp(String.Prototype, "__Enum", {call:__javascript_strings.__Enum})   
     }
+    ;Added by Laser_Made with the credit to Axelfublr 10/2/2022
+    static __Item[args*] {
+		get {
+			if args.length = 2
+				return SubStr(args[1], args[2], 1)
+			else {
+				len := StrLen(args[1])
+				if args[2] < 0
+					args[2] := len+args[2]+1
+				if args[3] < 0
+					args[3] := len+args[3]+1
+				if args[3] >= args[2]
+					return SubStr(args[1], args[2], args[3]-args[2]+1)
+				else
+					return SubStr(args[1], args[3], args[2]-args[3]+1).Reverse()
+			}
+		}
+	}
+    ;Added by Laser_Made with the credit to Descolada 3/1/2023
+	static __Enum(varCount) {
+		pos := 0, len := StrLen(this)
+		EnumElements(&char) {
+			char := StrGet(StrPtr(this) + 2*pos, 1)
+			return ++pos <= len
+		}
+		EnumIndexAndElements(&index, &char) {
+			char := StrGet(StrPtr(this) + 2*pos, 1), index := ++pos
+			return pos <= len
+		}
+		return varCount = 1 ? EnumElements : EnumIndexAndElements
+	}   
+
+    ; === Properties ===
+    static length => StrLen(this)
+
+    ; === Methods ===
+    
+    ; at() - Returns the character at a specified index (position). Can search negative indices
+    static at(index) => SubStr(this, index, 1)
+    
+    ; charAt() - Returns the character at a specified index (position)
+    static charAt(index) => index <= 0 ? 0 : SubStr(this, index, 1)
+
+    ; charCodeAt() - Returns the Unicode of the character at a specified index
+    static charCodeAt(index) => Ord(SubStr(this, index, 1))
+    
+    ; includes() - Returns true if a string contains a specified value
+    static includes(value, start_pos:=1) => InStr(this, value,, start_pos) ? 1 : 0
+    
+    ; indexOf() - Returns the index (position) of the first occurrence of a value in a string
+    static indexOf(value, start_pos:=1) => InStr(this, value,, start_pos)
+    
+    ; lastIndexOf() - Returns the index (position) of the last occurrence of a value in a string
+    static lastIndexOf(value, end_pos:=unset) => InStr(SubStr(this, 1, IsSet(end_pos) ? end_pos : unset), value,,, -1)
+    
+    ; replace() - Searches a string for a pattern, and returns a string where the first match is replaced
+    static replace(regex, replacement:='') => RegExReplace(this, regex, replacement)
+
+    ; replaceAll() - Searches a string for a pattern, and returns a string where every match is replaced
+    static replaceAll(args*) => StrReplace(this, args*)
+
+    ; search() - Searches a string for a value, or regular expression, and returns the index (position) of the match
+    static search(regex) => RegExMatch(this, regex)
+    
+    ; slice() - Extracts a part of a string and returns a new string
+    static slice(start:=1, end:=unset) => SubStr(this, start, IsSet(end) ? end-start+1 : unset)
+    
+    ; split() - Splits a string into an array of substrings
+    static split(delimiter:='', limit:=-1) => (limit = 0) ? [] : StrSplit(this, delimiter,'', limit)
+
+    ; substring() - Extracts characters from a string, between two specified indices (positions)
+    static substring(start, end:=unset) => SubStr(this, start, IsSet(end) ? end-start+1 : unset)
+        
+    ; toLowerCase() - Returns a string converted to lowercase letters
+    static toLowerCase() => StrLower(this)
+    
+    ; toUpperCase() - Returns a string converted to uppercase letters
+    static toUpperCase() => StrUpper(this)
+    
+    ; trim() - Returns a string with removed whitespaces
+    static trim(chars:=' \t`n`r') => Trim(this, chars)
+    
+    ; trimEnd() - Returns a string with removed whitespaces from the end
+    static trimEnd(chars:=' \t`n`r') => RTrim(this, chars)
+    
+    ; trimStart() - Returns a string with removed whitespaces from the start
+    static trimStart(chars:=' \t`n`r') => LTrim(this, chars)
+
+ 
+    ;=======================
+    ; concat() - Returns two or more joined strings
+    static concat(strings*) {
+        for str in strings
+            this .= str
+        return this
+    }
+
+    ; endsWith() - Returns if a string ends with a specified value
+    static endsWith(search_str, end_pos:=unset) {
+        str_len := StrLen(this)
+        if !IsSet(end_pos)
+            end_pos := str_len
+        srch_len := StrLen(search_str)
+        if (SubStr(this, end_pos-srch_len+1, srch_len) = search_str)
+            return 1
+        return 0
+    }
+    
+    ; match() - Searches a string for a value, or regular expression, and returns the match
+    static match(regex) {
+        RegExMatch(this, regex, &m)
+        return m
+    }
+
+    ; matchAll() - Searches a string for a value, or regular expression, and returns the matches
+    static matchAll(RegEx, start := 1) {
+        results := Array()
+		While (start := RegExMatch(this, RegEx, &match, start)) {
+			results.push(match)
+            start += match[0] ? StrLen(match[0]) : 1
+        }
+        return results
+    }
+    
+    ; padEnd() - Pads the end of the string to a given length with with a given string. Repeats if needed.
+    static padEnd(length, pad:=' ') {
+        while (StrLen(this) != length)
+            loop parse pad
+                this .= A_LoopField
+            until (StrLen(this) = length)
+        return this
+    }
+    
+    ; padStart() - Pads the end of the string to a given length with with a given string. Repeats if needed.
+    static padStart(length, pad:=' ') {
+        while (StrLen(this) != length)
+            loop parse pad
+                this := A_LoopField this
+            until (StrLen(this) = length)
+        return this
+    }
+    
+    ; repeat() - Returns a new string with a number of copies of a string
+    static repeat(count) {
+        str := ''
+        loop count
+            str .= this
+        return str
+    }
+    
+    ; startsWith() - Checks whether a string begins with specified characters
+    static startsWith(search_str, start_pos:=1) {
+        if (search_str = SubStr(this, start_pos, StrLen(search_str)))
+            return 1
+        return 0
+    }
+
+    ; valueOf() - Returns this string value.
+    static valueOf() => this
+
 }

--- a/src/javascript_strings.ahk
+++ b/src/javascript_strings.ahk
@@ -1,3 +1,10 @@
+/***
+ * @author GroggyOtter
+ * @created 04/21/2024
+ * @contributors Laser_Made, Axelfublr, Descolada
+ * @contributions LaserMade on 08/02/2024 static methods (__Item & __Enum) along with at(), matchAll(), replaceAll(), valueOf() and respective descriptions
+ * @updated 08/02/2024
+ */
 class __javascript_strings {
     static __New() {
 		__ObjDefineProp := Object.Prototype.DefineProp
@@ -7,7 +14,7 @@ class __javascript_strings {
 		__ObjDefineProp(String.Prototype, "__Item", {get:(args*)=>__javascript_strings.__Item[args*]})
 		__ObjDefineProp(String.Prototype, "__Enum", {call:__javascript_strings.__Enum})   
     }
-    ;Added by Laser_Made with the credit to Axelfublr 10/2/2022
+    ;Added by Laser_Made 08/02/2024 (with credit to Axelfublr 10/2/2022)
     static __Item[args*] {
 		get {
 			if args.length = 2
@@ -25,7 +32,7 @@ class __javascript_strings {
 			}
 		}
 	}
-    ;Added by Laser_Made with the credit to Descolada 3/1/2023
+    ;Added by Laser_Made 08/02/2024 (with credit to Descolada 3/1/2023)
 	static __Enum(varCount) {
 		pos := 0, len := StrLen(this)
 		EnumElements(&char) {
@@ -44,7 +51,10 @@ class __javascript_strings {
 
     ; === Methods ===
     
-    ; at() - Returns the character at a specified index (position). Can search negative indices
+    /**
+     * @returns {String} the character at a specified index (position). Can search negative indices
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/at|String.at() on MDN}
+     */
     static at(index) => SubStr(this, index, 1)
     
     ; charAt() - Returns the character at a specified index (position)
@@ -70,7 +80,12 @@ class __javascript_strings {
             return RegExReplace(this, regex := needle, replacement)
         }
     }
-    ; replaceAll() - Searches a string for a pattern, and returns a string where every match is replaced
+
+    /**
+     * @description replaces all occurrences of a string, not just the first one. Does not mutate the original string.
+     * @returns {String} Searches a string for a pattern, and returns a string with every match having been replaced
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll|String.replaceAll() on MDN}
+     */
     static replaceAll(args*) => RegExReplace(this, args*)
 
     ; search() - Searches a string for a value, or regular expression, and returns the index (position) of the match
@@ -126,7 +141,11 @@ class __javascript_strings {
         return m
     }
 
-    ; matchAll() - Searches a string for a value, or regular expression, and returns the matches
+    /**
+     * @description Searches a string for a value, or regular expression, and returns the matches
+     * @returns {Object} The matched strings where every match is found
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll|String.matchAll() on MDN}
+     */
     static matchAll(RegEx, start := 1) {
         results := Array()
 		While (start := RegExMatch(this, RegEx, &match, start)) {


### PR DESCRIPTION
Primarily added `__item` and `__enum` to enable direct value access like in JavaScript. Added methods:
`at(), replaceAll(), matchAll(), valueOf()`
Modified methods:
`charAt()` to reflect the addition of `at()` and make it function accordingly

changed
`String.Prototype.DefineProp := Object.Prototype.DefineProp`
and all of the other `String.Prototype.DefineProp('propertyName', {call: method})` lines
to
(see LM branch lines 3 -> 8)
[from Descolada's lib](https://github.com/Descolada/AHK-v2-libraries/blob/main/Lib/String.ahk)
Which is also where I borrowed `__enum` and `__item` from. 